### PR TITLE
Fix Incorrect Channel Routing for Workload Findings

### DIFF
--- a/rocketchat-notification/lambda/index.py
+++ b/rocketchat-notification/lambda/index.py
@@ -6,6 +6,7 @@ import requests
 import time
 import os
 import math
+import re
 import urllib.parse
 from os import environ
 from datetime import datetime
@@ -175,10 +176,25 @@ def handler(event, context):
 
                     colour = "#7CD197"
                     severity = ""
+                    
                     if account in core_accounts:
-                        accountType = "core"
+                        match = re.findall(r'arn:aws:\w+:.?:(\d{12})', findingDescription)
+                        if match:
+                            account_number = match[1]
+                            logging.getLogger().info(account_number)
+                            if account_number in core_accounts:
+                                    logging.getLogger().info("Case account number in core account")
+                                    accountType = "core"
+                            else:
+                                logging.getLogger().info("Case account number not core account")
+                                accountType = "workload"
+                        else:
+                            logging.getLogger().info("Case arn no match")
+                            accountType = "core"
                     else:
+                        logging.getLogger().info("case account id not in core account")
                         accountType = "workload"
+
                     severityNormalized = finding["Severity"]["Normalized"]
 
                     if 1 <= severityNormalized and severityNormalized <= 39:

--- a/rocketchat-notification/lambda/requirements.txt
+++ b/rocketchat-notification/lambda/requirements.txt
@@ -1,3 +1,4 @@
 jsonschema
 boto3
 requests
+botocore

--- a/rocketchat-notification/variables.tf
+++ b/rocketchat-notification/variables.tf
@@ -14,8 +14,10 @@ variable "LambdaTimeout" {
 }
 
 variable "ParentId" {
-  type = string
+  type        = string
+  description = "Id of the security group"
 }
 variable "ParentId1" {
-  type = string
+  type        = string
+  description = "Id of the Infrastructure group"
 }


### PR DESCRIPTION
## Description 
When security hub finds issue for workloads account, the lambda was redirecting them as a core account findings.
We have change the code to recognise them as workloads account findings

# Changes
 - [x] Add logic to analize content of the finding to find account impacted
 - [x] Add variable description to ease deployement
 
 # Tests
 - [x] terraform plan
 - [x] terraform apply
 - [x] Lambda redirection works 